### PR TITLE
convert packetType from uint16_t to String

### DIFF
--- a/Libraries/SparkFun I2C GPS/src/SparkFun_I2C_GPS_Arduino_Library.cpp
+++ b/Libraries/SparkFun I2C GPS/src/SparkFun_I2C_GPS_Arduino_Library.cpp
@@ -183,7 +183,7 @@ String I2CGPS::createMTKpacket(uint16_t packetType, String dataField)
   //Append any leading zeros
   if (packetType < 100) configSentence += "0";
   if (packetType < 10) configSentence += "0";
-  configSentence += packetType;
+  configSentence += String(packetType);
 
   //Attach any settings
   if (dataField.length() > 0)


### PR DESCRIPTION
XA1110 doesn't 'appear' to respond to sending createMTKpacket(uint16_t packetType, String dataField) as the packetType currently is. Experimenting with changing the type to String